### PR TITLE
Fixes #11 Provide .NET Standard library

### DIFF
--- a/src/MPFit.sln
+++ b/src/MPFit.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26606.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MPFitLib.NET20", "MPFitLib.NET20\MPFitLib.NET20.csproj", "{58843302-1DA2-41E9-BC81-6D6A5151F7DD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MPFitLib.Test", "MPFitLib.Test\MPFitLib.Test.csproj", "{D7AAC6D1-35D7-4613-8A13-9B786135C097}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MPFitLib.Silverlight", "MPFitLib.Silverlight\MPFitLib.Silverlight.csproj", "{A11547D5-B90D-4A29-BF9B-C03CC7159E3B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MPFitLib.NETStandard", "MPFitLib.NETStandard\MPFitLib.NETStandard.csproj", "{A520C61A-D94A-43EF-9456-ADA7D0DABF6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{A11547D5-B90D-4A29-BF9B-C03CC7159E3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A11547D5-B90D-4A29-BF9B-C03CC7159E3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A11547D5-B90D-4A29-BF9B-C03CC7159E3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A520C61A-D94A-43EF-9456-ADA7D0DABF6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A520C61A-D94A-43EF-9456-ADA7D0DABF6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A520C61A-D94A-43EF-9456-ADA7D0DABF6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A520C61A-D94A-43EF-9456-ADA7D0DABF6B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MPFitLib.NETStandard/MPFitLib.NETStandard.csproj
+++ b/src/MPFitLib.NETStandard/MPFitLib.NETStandard.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MPFitLib\DelimitedArrayOfT.cs" Link="DelimitedArrayOfT.cs" />
+    <Compile Include="..\MPFitLib\MPFit.cs" Link="MPFit.cs" />
+    <Compile Include="..\MPFitLib\mp_config.cs" Link="mp_config.cs" />
+    <Compile Include="..\MPFitLib\mp_func.cs" Link="mp_func.cs" />
+    <Compile Include="..\MPFitLib\mp_par.cs" Link="mp_par.cs" />
+    <Compile Include="..\MPFitLib\mp_result.cs" Link="mp_result.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/MPFitLib.Test/MPFitLib.Test.csproj
+++ b/src/MPFitLib.Test/MPFitLib.Test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MPFitLib.Test</RootNamespace>
     <AssemblyName>MPFitLib.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -31,7 +31,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\MPFitLib.Test.XML</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\MPFitLib.Test.XML</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -87,9 +90,9 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MPFitLib.NET20\MPFitLib.NET20.csproj">
-      <Project>{58843302-1da2-41e9-bc81-6d6a5151f7dd}</Project>
-      <Name>MPFitLib.NET20</Name>
+    <ProjectReference Include="..\MPFitLib.NETStandard\MPFitLib.NETStandard.csproj">
+      <Project>{a520c61a-d94a-43ef-9456-ada7d0dabf6b}</Project>
+      <Name>MPFitLib.NETStandard</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/MPFitLib.Test/app.config
+++ b/src/MPFitLib.Test/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0,Profile=Client"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>


### PR DESCRIPTION
Added a .NET Standard library, which allows us to support multiple runtime platforms with a single binary, including .NET Framework 4.5+, .NET Core 1.0+, Mono 4.6+, Xamarin.iOS 10+, Xamarin.Android 7+, and UWP 10+. For more, see:  https://docs.microsoft.com/en-us/dotnet/standard/library

Test project now references NETStandard, and has been accordingly upgraded to .NET 4.5 for that to work.

Aside: FWIW, VS 2017 now allows for creating NuGet packages on build from within the IDE. Not sure if you have experience with this (I don't), but might be something to set up to streamline deployment.
