### PR TITLE
Corrected declaration and definition of dvec in Jacobian computation. Connected to #3

### DIFF
--- a/src/MPFitLib.Test/ForwardModels.cs
+++ b/src/MPFitLib.Test/ForwardModels.cs
@@ -119,5 +119,31 @@ namespace MPFitLib.Test
 
             return 0;
         }
+
+        public static int LineFunc(double[] p, double[] dy, IList<double>[] dvec, object vars)
+        {
+            var lineFitData = (LineFitData)vars;
+            var x = lineFitData.X;
+            var y = lineFitData.Y;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                dy[i] = y[i] - (p[0] + p[1] * x[i]);
+                if (dvec != null)
+                {
+                    var dvec0 = dvec[0];
+                    var dvec1 = dvec[1];
+                    if (dvec0 != null)
+                    {
+                        dvec0[i] = -p[0];
+                    }
+                    if (dvec1 != null)
+                    {
+                        dvec1[i] = -x[i];
+                    }
+                }
+            }
+            return 0;
+        }
     }
 }

--- a/src/MPFitLib.Test/LineFitData.cs
+++ b/src/MPFitLib.Test/LineFitData.cs
@@ -1,0 +1,33 @@
+﻿/* 
+ * MINPACK-1 Least Squares Fitting Library
+ *
+ * Original public domain version by B. Garbow, K. Hillstrom, J. More'
+ *   (Argonne National Laboratory, MINPACK project, March 1980)
+ * 
+ * Translation to C Language by S. Moshier (moshier.net)
+ * Translation to C# Language by D. Cuccia (http://davidcuccia.wordpress.com)
+ * 
+ * Enhancements and packaging by C. Markwardt
+ *   (comparable to IDL fitting routine MPFIT
+ *    see http://cow.physics.wisc.edu/~craigm/idl/idl.html)
+ */
+
+/* Test routines for MPFit library
+   $Id: TestMPFit.cs,v 1.1 2010/05/04 dcuccia Exp $
+*/
+
+namespace MPFitLib.Test
+{
+    internal class LineFitData
+    {
+        public LineFitData(double[] x, double[] y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
+
+        public double[] X { get; }
+        public double[] Y { get; }
+    }
+
+}

--- a/src/MPFitLib.Test/MPFitLib.Test.csproj
+++ b/src/MPFitLib.Test/MPFitLib.Test.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Compile Include="CustomUserVariable.cs" />
     <Compile Include="ForwardModels.cs" />
+    <Compile Include="LineFitData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestMPFit.cs" />
   </ItemGroup>

--- a/src/MPFitLib.Test/TestMPFit.cs
+++ b/src/MPFitLib.Test/TestMPFit.cs
@@ -35,6 +35,7 @@ namespace MPFitLib.Test
                 TestQuadFix();
                 TestGaussFit();
                 TestGaussFix();
+                TestAnalyticDerivatives();
             }
 
             Console.ReadKey();
@@ -271,6 +272,33 @@ namespace MPFitLib.Test
             PrintResult(p, pactual, result);
 
             return 0;
+        }
+
+        private static void TestAnalyticDerivatives()
+        {
+            const double intercept = 7.0;
+            const double slope = -3.0;
+            var pactual = new double[] { intercept, slope };
+            var p = new double[] { 5.9, -1.1 };
+            var x = new double[] { -5, -3, -1, 0, 1, 3, 5 };
+            var y = new double[x.Length];
+
+
+            for (uint i = 0; i < x.Length; i++)
+            {
+                y[i] = intercept + slope * x[i];
+            }
+
+            var mpPar = new mp_par[] { new mp_par(), new mp_par() };
+            mpPar[0].side = 3;
+            mpPar[1].side = 3;
+
+            var result = new mp_result(2);
+
+            var status = MPFit.Solve(ForwardModels.LineFunc, x.Length, 2, p, mpPar, null, new LineFitData(x, y), ref result);
+
+            Console.Write("*** TestLineFit status = {0}\n", status);
+            PrintResult(p, pactual, result);
         }
 
         /* Simple routine to print the fit results */

--- a/src/MPFitLib/MPFit.cs
+++ b/src/MPFitLib/MPFit.cs
@@ -1207,7 +1207,6 @@ namespace MPFitLib
             int iflag = 0;
             double eps, h, temp;
             const double zero = 0.0;
-            IList<double>[] dvec;
             int hasAnalyticalDeriv = 0, hasNumericalDeriv = 0;
             int hasDebugDeriv = 0;
 
@@ -1216,7 +1215,7 @@ namespace MPFitLib
             ij = 0;
 
             //dvec = (double**)malloc(sizeof(double**) * npar);
-            dvec = new double[npar][];
+            var dvec = new DelimitedArray<double>[npar];
 
             //for (j = 0; j < npar; j++)
             //{


### PR DESCRIPTION
Fixes #3.

Proposed changes:

* Declare and define `dvec` in method `MPFit.mp_fdjac2` as array of `DelimitedArray` objects.