### PR TITLE
Sync csmpfit 1.5 changes (no functional change).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 # Project Description
 
-A C# port of the C-based [mpfit Levenberg Marquardt solver](http://cow.physics.wisc.edu/~craigm/idl/cmpfit.html) at Argonne National Labs, including desktop .NET (2.0 and higher), .NET Standard 1.0 and 2.0 libraries.
+A C# port of the C-based [mpfit Levenberg Marquardt solver (Version 1.5)](http://cow.physics.wisc.edu/~craigm/idl/cmpfit.html) at Argonne National Labs, including desktop .NET (2.0 and higher), .NET Standard 1.0 and 2.0 libraries.
 
 # Credits
 *csmpfit* is based on the following IDL and C mpfit libraries:

--- a/src/MPFitLib/MPFit.cs
+++ b/src/MPFitLib/MPFit.cs
@@ -20,6 +20,7 @@
    added changes from mpfit.h v1.16 2016/06/02
     and mpfit.c v1.24 2013/04/23
    added changes from mpfit version 1.4 (no file versions provided)
+   added changes from cmpfit version 1.5 (just a comment, since the bug was already fixed here)
  */
 
 using System;
@@ -30,7 +31,7 @@ namespace MPFitLib
 {
     public static class MPFit
     {
-        public const string MPFIT_VERSION = "1.4";
+        public const string MPFIT_VERSION = "1.5";
 
         public const int MP_NO_ITER = -1;
 
@@ -1305,7 +1306,7 @@ namespace MPFitLib
                     /* Skip parameters already done by user-computed partials */
                     if (dside != null && dsidei == 3)
                     {
-                        ij += m;
+                        ij += m; /* still need to advance fjac pointer */
                         continue;
                     }
 


### PR DESCRIPTION
@anders9ustafsson the bug was already fixed by you with PR #14. Here I just updated the version and the comment from the same fix in csmpfit 1.5.
So it is clear that csmpfit is in sync with cmpfit.